### PR TITLE
skip pols & fast debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
     },
     "node_modules/@0xpolygonhermez/zkasmcom": {
       "version": "0.0.17",
-      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkasmcom.git#cf67823ad4427d7885bb4812833f2ee45c85f305",
+      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkasmcom.git#b6570cf21e9b4e0899e07eec2a23ba8235316642",
       "license": "UNLICENSED",
       "dependencies": {
         "ffjavascript": "^0.2.46",
@@ -44,7 +44,7 @@
     },
     "node_modules/@0xpolygonhermez/zkevm-commonjs": {
       "version": "0.0.36",
-      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkevm-commonjs.git#3ff05cab6c0ba0880a7000adef0bc5d95566d797",
+      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkevm-commonjs.git#1d391bbeef26f5d008fde4d0073e2caa94f81ff1",
       "license": "pending",
       "dependencies": {
         "@ethereumjs/block": "^3.6.2",
@@ -60,7 +60,7 @@
     "node_modules/@0xpolygonhermez/zkevm-rom": {
       "name": "@0xpolygonhermez/zkrom",
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git#71f23335b29f438bf1230547ab8bfe0dbaf5b9b0",
+      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git#32e858905013d8d3fcb1537a33dd58dfd01c439a",
       "license": "pending",
       "dependencies": {
         "@0xpolygonhermez/zkasmcom": "git+ssh://git@github.com/0xPolygonHermez/zkasm.git"
@@ -68,7 +68,7 @@
     },
     "node_modules/@0xpolygonhermez/zkevm-rom/node_modules/@0xpolygonhermez/zkasmcom": {
       "version": "0.0.17",
-      "resolved": "git+ssh://git@github.com/0xPolygonHermez/zkasm.git#cf67823ad4427d7885bb4812833f2ee45c85f305",
+      "resolved": "git+ssh://git@github.com/0xPolygonHermez/zkasm.git#b6570cf21e9b4e0899e07eec2a23ba8235316642",
       "license": "UNLICENSED",
       "dependencies": {
         "ffjavascript": "^0.2.46",
@@ -850,7 +850,7 @@
     },
     "node_modules/@polygon-hermez/vm/node_modules/@0xpolygonhermez/zkevm-commonjs": {
       "version": "0.0.36",
-      "resolved": "git+ssh://git@github.com/0xPolygonHermez/zkevm-commonjs.git#993dd124ca5a545af935c7ad3f7fba45aea5dcf5",
+      "resolved": "git+ssh://git@github.com/0xPolygonHermez/zkevm-commonjs.git#72e459c01fbf68be1400e91ef416315f059693cb",
       "license": "pending",
       "dependencies": {
         "@ethereumjs/block": "^3.6.2",
@@ -892,9 +892,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.5.tgz",
-      "integrity": "sha512-En7tneq+j0qAiVwysBD79y86MT3ModuoIJbe7JXp+sb5UAjInSShmK3nXXMioBzfF7rXC12hv12d4IyCVwN4dA=="
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
+      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg=="
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.0",
@@ -1035,9 +1035,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.5.3.tgz",
-      "integrity": "sha512-1aCQIzQJK7G0z1Una75tWMlwVAR8o+QHoAlnWc5XAxRVBESY9WsitfBgM5nPyDBP5HrhPU1Np4Pq2Y7CJQ+tVw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.0.tgz",
+      "integrity": "sha512-fsTxXxj1081Yq5MOQ06gZ5+e2QcSyP2U6NofdOWyq+lrNI4IjkZ+fLVmoQ6uUCiNg1NWePMMVq93vOTdbJmErw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1434,9 +1434,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/core-js-pure": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.4.tgz",
-      "integrity": "sha512-lizxkcgj3XDmi7TUBFe+bQ1vNpD5E4t76BrBWI3HdUxdw/Mq1VF4CkiHzIKyieECKtcODK2asJttoofEeUKICQ==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.0.tgz",
+      "integrity": "sha512-uzMmW8cRh7uYw4JQtzqvGWRyC2T5+4zipQLQdi2FmiRqP83k3d6F3stv2iAlNhOs6cXN401FCD5TL0vvleuHgA==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -4027,7 +4027,7 @@
   },
   "dependencies": {
     "@0xpolygonhermez/zkasmcom": {
-      "version": "git+ssh://git@github.com/0xpolygonhermez/zkasmcom.git#cf67823ad4427d7885bb4812833f2ee45c85f305",
+      "version": "git+ssh://git@github.com/0xpolygonhermez/zkasmcom.git#b6570cf21e9b4e0899e07eec2a23ba8235316642",
       "from": "@0xpolygonhermez/zkasmcom@git+ssh://git@github.com/0xpolygonhermez/zkasmcom.git",
       "requires": {
         "ffjavascript": "^0.2.46",
@@ -4036,7 +4036,7 @@
       }
     },
     "@0xpolygonhermez/zkevm-commonjs": {
-      "version": "git+ssh://git@github.com/0xpolygonhermez/zkevm-commonjs.git#3ff05cab6c0ba0880a7000adef0bc5d95566d797",
+      "version": "git+ssh://git@github.com/0xpolygonhermez/zkevm-commonjs.git#1d391bbeef26f5d008fde4d0073e2caa94f81ff1",
       "from": "@0xpolygonhermez/zkevm-commonjs@git+ssh://git@github.com/0xpolygonhermez/zkevm-commonjs.git",
       "requires": {
         "@ethereumjs/block": "^3.6.2",
@@ -4050,14 +4050,14 @@
       }
     },
     "@0xpolygonhermez/zkevm-rom": {
-      "version": "git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git#71f23335b29f438bf1230547ab8bfe0dbaf5b9b0",
+      "version": "git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git#32e858905013d8d3fcb1537a33dd58dfd01c439a",
       "from": "@0xpolygonhermez/zkevm-rom@git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git",
       "requires": {
         "@0xpolygonhermez/zkasmcom": "git+ssh://git@github.com/0xPolygonHermez/zkasm.git"
       },
       "dependencies": {
         "@0xpolygonhermez/zkasmcom": {
-          "version": "git+ssh://git@github.com/0xPolygonHermez/zkasm.git#cf67823ad4427d7885bb4812833f2ee45c85f305",
+          "version": "git+ssh://git@github.com/0xPolygonHermez/zkasm.git#b6570cf21e9b4e0899e07eec2a23ba8235316642",
           "from": "@0xpolygonhermez/zkasmcom@git+ssh://git@github.com/0xPolygonHermez/zkasm.git",
           "requires": {
             "ffjavascript": "^0.2.46",
@@ -4539,7 +4539,7 @@
       },
       "dependencies": {
         "@0xpolygonhermez/zkevm-commonjs": {
-          "version": "git+ssh://git@github.com/0xPolygonHermez/zkevm-commonjs.git#993dd124ca5a545af935c7ad3f7fba45aea5dcf5",
+          "version": "git+ssh://git@github.com/0xPolygonHermez/zkevm-commonjs.git#72e459c01fbf68be1400e91ef416315f059693cb",
           "from": "@0xpolygonhermez/zkevm-commonjs@github:0xPolygonHermez/zkevm-commonjs#v0.0.36",
           "requires": {
             "@ethereumjs/block": "^3.6.2",
@@ -4583,9 +4583,9 @@
       }
     },
     "@types/node": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.5.tgz",
-      "integrity": "sha512-En7tneq+j0qAiVwysBD79y86MT3ModuoIJbe7JXp+sb5UAjInSShmK3nXXMioBzfF7rXC12hv12d4IyCVwN4dA=="
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
+      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg=="
     },
     "@types/pbkdf2": {
       "version": "3.1.0",
@@ -4696,9 +4696,9 @@
       "dev": true
     },
     "b4a": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.5.3.tgz",
-      "integrity": "sha512-1aCQIzQJK7G0z1Una75tWMlwVAR8o+QHoAlnWc5XAxRVBESY9WsitfBgM5nPyDBP5HrhPU1Np4Pq2Y7CJQ+tVw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.0.tgz",
+      "integrity": "sha512-fsTxXxj1081Yq5MOQ06gZ5+e2QcSyP2U6NofdOWyq+lrNI4IjkZ+fLVmoQ6uUCiNg1NWePMMVq93vOTdbJmErw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -5015,9 +5015,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "core-js-pure": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.4.tgz",
-      "integrity": "sha512-lizxkcgj3XDmi7TUBFe+bQ1vNpD5E4t76BrBWI3HdUxdw/Mq1VF4CkiHzIKyieECKtcODK2asJttoofEeUKICQ=="
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.0.tgz",
+      "integrity": "sha512-uzMmW8cRh7uYw4JQtzqvGWRyC2T5+4zipQLQdi2FmiRqP83k3d6F3stv2iAlNhOs6cXN401FCD5TL0vvleuHgA=="
     },
     "crc-32": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ffjavascript": "^0.2.55",
         "fs": "^0.0.1-security",
         "pil-stark": "^0.0.6",
-        "pilcom": "^0.0.9",
+        "pilcom": "github:0xPolygonHermez/pilcom#feature/skipStateMachines ",
         "yargs": "^17.4.0"
       },
       "devDependencies": {
@@ -60,7 +60,7 @@
     "node_modules/@0xpolygonhermez/zkevm-rom": {
       "name": "@0xpolygonhermez/zkrom",
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git#32e858905013d8d3fcb1537a33dd58dfd01c439a",
+      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git#fcdf12a75752c5b869a835de7fadd0d6b54a9eb5",
       "license": "pending",
       "dependencies": {
         "@0xpolygonhermez/zkasmcom": "git+ssh://git@github.com/0xPolygonHermez/zkasm.git"
@@ -892,9 +892,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg=="
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.0",
@@ -3308,6 +3308,15 @@
         "ffjavascript": "^0.2.45"
       }
     },
+    "node_modules/pil-stark/node_modules/pilcom": {
+      "version": "0.0.9",
+      "resolved": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git#ed95b2a5229747ceb5a10500610562f641b52c5d",
+      "license": "UNLICENSED",
+      "bin": {
+        "pilcom": "src/pil.js",
+        "pilverifier": "src/main_pilverifier.js"
+      }
+    },
     "node_modules/pil-stark/node_modules/wasmcurves": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.1.5.tgz",
@@ -3324,7 +3333,7 @@
     },
     "node_modules/pilcom": {
       "version": "0.0.9",
-      "resolved": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git#ed95b2a5229747ceb5a10500610562f641b52c5d",
+      "resolved": "git+ssh://git@github.com/0xPolygonHermez/pilcom.git#002dcf3be30cf0bdace0c873813fad490f6a44ec",
       "license": "UNLICENSED",
       "bin": {
         "pilcom": "src/pil.js",
@@ -4050,7 +4059,7 @@
       }
     },
     "@0xpolygonhermez/zkevm-rom": {
-      "version": "git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git#32e858905013d8d3fcb1537a33dd58dfd01c439a",
+      "version": "git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git#fcdf12a75752c5b869a835de7fadd0d6b54a9eb5",
       "from": "@0xpolygonhermez/zkevm-rom@git+ssh://git@github.com/0xpolygonhermez/zkevm-rom.git",
       "requires": {
         "@0xpolygonhermez/zkasmcom": "git+ssh://git@github.com/0xPolygonHermez/zkasm.git"
@@ -4583,9 +4592,9 @@
       }
     },
     "@types/node": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg=="
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
     },
     "@types/pbkdf2": {
       "version": "3.1.0",
@@ -6400,6 +6409,10 @@
             "ffjavascript": "^0.2.45"
           }
         },
+        "pilcom": {
+          "version": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git#ed95b2a5229747ceb5a10500610562f641b52c5d",
+          "from": "pilcom@git+ssh://git@github.com/0xpolygonhermez/pilcom.git"
+        },
         "wasmcurves": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.1.5.tgz",
@@ -6417,8 +6430,8 @@
       }
     },
     "pilcom": {
-      "version": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git#ed95b2a5229747ceb5a10500610562f641b52c5d",
-      "from": "pilcom@^0.0.9"
+      "version": "git+ssh://git@github.com/0xPolygonHermez/pilcom.git#002dcf3be30cf0bdace0c873813fad490f6a44ec",
+      "from": "pilcom@github:0xPolygonHermez/pilcom#feature/skipStateMachines "
     },
     "prr": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "ethers": "^5.4.7",
         "ffjavascript": "^0.2.55",
         "fs": "^0.0.1-security",
-        "pil-stark": "git+ssh://git@github.com/0xpolygonhermez/pil-stark.git",
-        "pilcom": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git",
+        "pil-stark": "^0.0.6",
+        "pilcom": "^0.0.9",
         "yargs": "^17.4.0"
       },
       "devDependencies": {
@@ -3284,9 +3284,9 @@
       }
     },
     "node_modules/pil-stark": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/0xpolygonhermez/pil-stark.git#39c028333f22908ac96b42198c9d95724e74908e",
-      "license": "UNLICENSED",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/pil-stark/-/pil-stark-0.0.6.tgz",
+      "integrity": "sha512-mE1Dp0Ux4VXb/90fsQVCxV/K7JgEk980udNeB6H1mEUnN09b0nJw5KONkaplVjbUf02ZHXzh4f2Z9WCqD46x/w==",
       "dependencies": {
         "circom_runtime": "^0.1.18",
         "circomlibjs": "^0.1.6",
@@ -3323,8 +3323,8 @@
       "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw=="
     },
     "node_modules/pilcom": {
-      "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git#c6b0e05a9b13ba86271652dadb2196cac7281d7b",
+      "version": "0.0.9",
+      "resolved": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git#ed95b2a5229747ceb5a10500610562f641b52c5d",
       "license": "UNLICENSED",
       "bin": {
         "pilcom": "src/pil.js",
@@ -6376,8 +6376,9 @@
       "dev": true
     },
     "pil-stark": {
-      "version": "git+ssh://git@github.com/0xpolygonhermez/pil-stark.git#39c028333f22908ac96b42198c9d95724e74908e",
-      "from": "pil-stark@git+ssh://git@github.com/0xpolygonhermez/pil-stark.git",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/pil-stark/-/pil-stark-0.0.6.tgz",
+      "integrity": "sha512-mE1Dp0Ux4VXb/90fsQVCxV/K7JgEk980udNeB6H1mEUnN09b0nJw5KONkaplVjbUf02ZHXzh4f2Z9WCqD46x/w==",
       "requires": {
         "circom_runtime": "^0.1.18",
         "circomlibjs": "^0.1.6",
@@ -6416,8 +6417,8 @@
       }
     },
     "pilcom": {
-      "version": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git#c6b0e05a9b13ba86271652dadb2196cac7281d7b",
-      "from": "pilcom@git+ssh://git@github.com/0xpolygonhermez/pilcom.git"
+      "version": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git#ed95b2a5229747ceb5a10500610562f641b52c5d",
+      "from": "pilcom@^0.0.9"
     },
     "prr": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ffjavascript": "^0.2.55",
     "fs": "^0.0.1-security",
     "pil-stark": "^0.0.6",
-    "pilcom": "^0.0.9",
+    "pilcom": "github:0xPolygonHermez/pilcom#feature/skipStateMachines ",  
     "yargs": "^17.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "ethers": "^5.4.7",
     "ffjavascript": "^0.2.55",
     "fs": "^0.0.1-security",
-    "yargs": "^17.4.0",
-    "pilcom": "git+ssh://git@github.com/0xpolygonhermez/pilcom.git",
-    "pil-stark": "git+ssh://git@github.com/0xpolygonhermez/pil-stark.git"
+    "pil-stark": "^0.0.6",
+    "pilcom": "^0.0.9",
+    "yargs": "^17.4.0"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/src/sm/sm_main/sm_main_exec.js
+++ b/src/sm/sm_main/sm_main_exec.js
@@ -43,16 +43,7 @@ module.exports = async function execute(pols, input, rom, config = {}) {
         testTools.setup(config.test, evalCommand);
     }
 
-    let N;
-
-    if ((config)&&(config.debug)) {
-        if((config.debugInfo)&&(config.debugInfo.N))
-            N = Number(2**config.debugInfo.N)
-        else
-            N = Number(2**17);
-    } else {
-        N = pols.zkPC.length;
-    }
+    const N = pols.zkPC.length;
 
     const poseidon = await buildPoseidon();
     const Fr = poseidon.F;
@@ -64,8 +55,6 @@ module.exports = async function execute(pols, input, rom, config = {}) {
     initState(Fr, pols);
 
     let op7, op6, op5, op4, op3, op2, op1, op0;
-
-    let ln;
 
     const ctx = {
         mem: [],
@@ -93,8 +82,6 @@ module.exports = async function execute(pols, input, rom, config = {}) {
     }
     const iPrint = new Prints(ctx, smt);
 
-    // only for debugging
-    let __incCounterPos = 0;
     for (i=0; i<N; i++) {
         ctx.ln = Fr.toObject(pols.zkPC[i]);
         ctx.step=i;
@@ -123,6 +110,11 @@ module.exports = async function execute(pols, input, rom, config = {}) {
 
         ctx.fileName = l.fileName;
         ctx.line = l.line;
+
+        // breaks the loop in debug mode in order to test and debug faster
+        if (config.debug && l.fileName.includes("end.zkasm")) {
+            break;
+        }
 
         let incHashPos = 0;
         let incCounter = 0;

--- a/tools/run-test/run-inputs.js
+++ b/tools/run-test/run-inputs.js
@@ -82,7 +82,8 @@ async function main(){
         await fs.promises.writeFile(fileCachePil, JSON.stringify(pil, null, 1) + "\n", "utf8");
     }
 
-    const cmPols = newCommitPolsArray(pil);
+    const commitConfig = {includeStateMachines: ["Main"]};
+    const cmPols = newCommitPolsArray(pil, commitConfig);
 
     let first = "";
     let second = "";


### PR DESCRIPTION
- remove unused variables
- skip unnecessary `pil` and `state-machines` when debugging `main`
- adapt to refactor `run-inputs.js` & `run-inputsChildProcess.js`
- remove `-n` parameter
- add `break` to debug faster added before by @invocamanman 
- it is necessary to add the `node --max-old-space-size=4096` option