### PR TITLE
Hash controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ npm run buildall --starkstruct=debug
 ```sh
 npm run buildall --build=build/basic_proof
 ```
+**input**: with this option indicates input file to use.
+```sh
+npm run buildall --input=test/myinputfile.json
+```
 ### Build steps
 - **buildrom**
 - **buildconstants**

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "buildproof": "tools/build_all.sh exec pilverify prove verify c12exec c12pilverify c12prove c12verify g16wc g16prove g16verify",
     "buildrom": ". ./pre.sh && (cd node_modules/@0xpolygonhermez/zkevm-rom && npm run build) && cp node_modules/@0xpolygonhermez/zkevm-rom/build/rom.json $BDIR/rom.json",
     "buildconstants": ". ./pre.sh && node $NODE src/main_buildconstants $PIL -r $BDIR/rom.json -o $BDIR/zkevm.const",
-    "exec": ". ./pre.sh && node $NODE src/main_executor tools/build-genesis/input_executor.json $PIL -r $BDIR/rom.json -o $BDIR/zkevm.commit && cp tools/build-genesis/input_executor.json $BDIR",
+    "exec": ". ./pre.sh && INPUT=${npm_config_input:=tools/build-genesis/input_executor.json} && echo \"input: $INPUT\" && node $NODE src/main_executor $INPUT $PIL -r $BDIR/rom.json -o $BDIR/zkevm.commit && cp $INPUT $BDIR/input_executor.json",
     "pilverify": ". ./pre.sh && $PILCOM/main_pilverifier.js $BDIR/zkevm.commit -c $BDIR/zkevm.const $PIL",
     "buildstarkinfo": ". ./pre.sh && $PILSTARK/main_genstarkinfo.js $PIL -s $BDIR/zkevm.starkstruct.json -i $BDIR/zkevm.starkinfo.json",
     "buildchelpers": ". ./pre.sh && $PILSTARK/main_buildchelpers.js $PIL -s $BDIR/zkevm.starkstruct.json -c $BDIR/zkevm.chelpers.cpp",

--- a/pre.sh
+++ b/pre.sh
@@ -2,8 +2,8 @@ BDIR="${npm_config_build:=build/proof}"
 mkdir -p $BDIR
 # NODE="--trace-gc --trace-gc-ignore-scavenger --max-semi-space-size=1024 --max-old-space-size=524288"
 MEM=130000
-type free tail sed >/dev/null 2>&1 && MEM=`free -t|tail -1|sed 's/Total: *\([0-9]*\).*/\1/'`
-MEM=$((MEM * 9/10))
+type head free tail sed >/dev/null 2>&1 && MEM=`free|head -2|tail -1|sed 's/Mem: *\([0-9]*\).*/\1/'`
+MEM=$((MEM * 9/10000))
 [ $MEM -gt 524288 ] && MEM=524288
 NODE="--max-old-space-size=$MEM"
 PIL="-p ${npm_config_pil:=pil/main.pil}`[ ! -z $npm_config_pilconfig ] && echo \" -P $npm_config_pilconfig\"`"

--- a/src/sm/sm_main/sm_main_exec.js
+++ b/src/sm/sm_main/sm_main_exec.js
@@ -963,7 +963,7 @@ module.exports = async function execute(pols, input, rom, config = {}) {
 
             const paddingA = Scalar.shr(a, size * 8);
             if (!Scalar.isZero(paddingA)) {
-//                throw new Error(`Incoherent size (${size}) and data (0x${a.toString(16)}) padding (0x${paddingA.toString(16)}) for hashK (w=${i}): ${ctx.ln} at ${ctx.fileName}:${ctx.line}`);
+                throw new Error(`Incoherent size (${size}) and data (0x${a.toString(16)}) padding (0x${paddingA.toString(16)}) for hashK (w=${i}): ${ctx.ln} at ${ctx.fileName}:${ctx.line}`);
             }
 
             if ((typeof ctx.hashK[addr].reads[pos] !== "undefined") &&

--- a/src/sm/sm_main/sm_main_exec.js
+++ b/src/sm/sm_main/sm_main_exec.js
@@ -948,7 +948,7 @@ module.exports = async function execute(pols, input, rom, config = {}) {
             pols.hashK[i] = 1n;
             const size = fe2n(Fr, ctx.D[0], ctx);
             const pos = fe2n(Fr, ctx.HASHPOS, ctx);
-            if ((size<0) || (size>32)) throw new Error(`Invalid size for hash: ${ctx.ln} at ${ctx.fileName}:${ctx.line}`);
+            if ((size<0) || (size>32)) throw new Error(`Invalid size for hashK: ${ctx.ln} at ${ctx.fileName}:${ctx.line}`);
             const a = fea2scalar(Fr, [op0, op1, op2, op3, op4, op5, op6, op7]);
             const maskByte = Scalar.e("0xFF");
             for (let i=0; i<size; i++) {
@@ -957,9 +957,15 @@ module.exports = async function execute(pols, input, rom, config = {}) {
                 if (typeof bh === "undefined") {
                     ctx.hashK[addr].data[pos + i] = bm;
                 } else if (bm != bh) {
-                    throw new Error(`HashK do not match ${addr}:${pos+i} is ${bm} and should be ${bh}`)
+                    throw new Error(`HashK do not match ${addr}:${pos+i} is ${bm} and should be ${bh}: ${ctx.ln} at ${ctx.fileName}:${ctx.line}`)
                 }
             }
+
+            const paddingA = Scalar.shr(a, size * 8);
+            if (!Scalar.isZero(paddingA)) {
+//                throw new Error(`Incoherent size (${size}) and data (0x${a.toString(16)}) padding (0x${paddingA.toString(16)}) for hashK (w=${i}): ${ctx.ln} at ${ctx.fileName}:${ctx.line}`);
+            }
+
             if ((typeof ctx.hashK[addr].reads[pos] !== "undefined") &&
                 (ctx.hashK[addr].reads[pos] != size))
             {
@@ -1021,6 +1027,11 @@ module.exports = async function execute(pols, input, rom, config = {}) {
                     throw new Error(`HashP do not match ${addr}:${pos+i} is ${bm} and should be ${bh}`)
                 }
             }
+            const paddingA = Scalar.shr(a, size * 8);
+            if (!Scalar.isZero(paddingA)) {
+                throw new Error(`Incoherent size (${size}) and data (0x${a.toString(16)}) padding (0x${paddingA.toString(16)}) for hashP (w=${i}): ${ctx.ln} at ${ctx.fileName}:${ctx.line}`);
+            }
+
             if ((typeof ctx.hashP[addr].reads[pos] !== "undefined") &&
                 (ctx.hashP[addr].reads[pos] != size))
             {


### PR DESCRIPTION
Add some controls to verify that only bytes used on hash were different from zero, the rest of the bytes unused must be zero for the plookup match.
Add the parameter --input on scripts call to change input file used.
Fix a bug on script used to calculate system memory