### PR TITLE
Replaced the use of MemDB with the new Database class (supports connecting to a PostgreSQL DB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "buildproof:basic": "npm run buildproof --pil=pil/basic_main.pil --build=build/basic_proof --starkstruct=debug",
 
     "test": "mocha",
-    "test:storage": "mocha test/sm_storage_test.js",
+    "test:storage": "mocha test/sm/sm_storage/sm_storage_test.js",
     "test:mem_align": "mocha test/sm_mem_align_test.js",
     "test:counters:arith": "mocha test/counters/arith.js",
     "test:counters:binary": "mocha test/counters/binary.js",

--- a/src/build_genesis.js
+++ b/src/build_genesis.js
@@ -1,4 +1,4 @@
-const { SMT, MemDB }  = require("@0xpolygonhermez/zkevm-commonjs");
+const { SMT, Database }  = require("@0xpolygonhermez/zkevm-commonjs");
 const { stringToH4 } = require("@0xpolygonhermez/zkevm-commonjs/src/smt-utils");
 const { keyEthAddrBalance, h4toString } = require("@0xpolygonhermez/zkevm-commonjs").smtUtils;
 const buildPoseidon = require("@0xpolygonhermez/zkevm-commonjs").getPoseidon;
@@ -38,7 +38,7 @@ async function run() {
     const poseidon = await buildPoseidon();
     const F = poseidon.F;
 
-    const db = new MemDB(F);
+    const db = new Database(F);
     const smt = new SMT(db, poseidon, F);
 
     let r = {

--- a/src/main_executor.js
+++ b/src/main_executor.js
@@ -28,7 +28,7 @@ const fileCachePil = path.join(__dirname, "../cache-main-pil.json");
 
 const argv = require("yargs")
     .version(version)
-    .usage("main_executor <input.json> -r <rom.json> -o <proof.json> -t <test.json> -l <logs.json> -s -d [-p <main.pil>] [-P <pilconfig.json>] [-D <databaseurl>] [-T <dbtable>] -u -e -v")
+    .usage("main_executor <input.json> -r <rom.json> -o <proof.json> -t <test.json> -l <logs.json> -s -d [-p <main.pil>] [-P <pilconfig.json>] [-D <databaseurl>] [-N <dbnodestable>] [-G <dbprogamtable>] -u -e -v")
     .alias("o", "output")
     .alias("r", "rom")
     .alias("t", "test")
@@ -41,7 +41,8 @@ const argv = require("yargs")
     .alias("e", "execute")
     .alias("v", "verbose")
     .alias("D", "databaseurl")
-    .alias("T", "dbtable")
+    .alias("N", "dbnodestable")
+    .alias("G", "dbprogramtable")    
     .argv;
 
 async function run() {
@@ -109,7 +110,8 @@ async function run() {
         unsigned: (argv.unsigned === true),
         execute: (argv.execute === true),
         databaseURL: typeof(argv.databaseurl) === "string" ?  argv.databaseurl.trim() : "local",
-        dbTable: typeof(argv.dbtable) === "string" ?  argv.dbtable.trim() : "state.merkletree"
+        dbNodesTable: typeof(argv.dbnodestable) === "string" ?  argv.dbnodestable.trim() : "state.nodes",
+        dbProgramTable: typeof(argv.dbprogramtable) === "string" ?  argv.dbprogramtable.trim() : "state.program"
     }
 
     const N = cmPols.Main.PC.length;

--- a/src/main_executor.js
+++ b/src/main_executor.js
@@ -28,7 +28,7 @@ const fileCachePil = path.join(__dirname, "../cache-main-pil.json");
 
 const argv = require("yargs")
     .version(version)
-    .usage("main_executor <input.json> -r <rom.json> -o <proof.json> -t <test.json> -l <logs.json> -s -d [-p <main.pil>] [-P <pilconfig.json>] -u -e -v")
+    .usage("main_executor <input.json> -r <rom.json> -o <proof.json> -t <test.json> -l <logs.json> -s -d [-p <main.pil>] [-P <pilconfig.json>] [-D <databaseurl>] [-T <dbtable>] -u -e -v")
     .alias("o", "output")
     .alias("r", "rom")
     .alias("t", "test")
@@ -39,8 +39,9 @@ const argv = require("yargs")
     .alias("P", "pilconfig")
     .alias("u", "unsigned")
     .alias("e", "execute")
-    .alias("P", "pilconfig")
     .alias("v", "verbose")
+    .alias("D", "databaseurl")
+    .alias("T", "dbtable")
     .argv;
 
 async function run() {
@@ -62,7 +63,7 @@ async function run() {
     const romFile = typeof(argv.rom) === "string" ?  argv.rom.trim() : "rom.json";
     const outputFile = typeof(argv.output) === "string" ?  argv.output.trim() : undefined;
     const testFile = typeof(argv.test) === "string" ?  argv.test.trim() : false;
-    const logsFile = typeof(argv.logs) === "string" ?  argv.output.trim() : undefined;
+    const logsFile = typeof(argv.logs) === "string" ?  argv.logs.trim() : undefined;
 
     const input = JSON.parse(await fs.promises.readFile(inputFile, "utf8"));
     const rom = JSON.parse(await fs.promises.readFile(romFile, "utf8"));
@@ -106,7 +107,9 @@ async function run() {
             inputName: path.basename(inputFile, ".json")
         },
         unsigned: (argv.unsigned === true),
-        execute: (argv.execute === true)
+        execute: (argv.execute === true),
+        databaseURL: typeof(argv.databaseurl) === "string" ?  argv.databaseurl.trim() : "local",
+        dbTable: typeof(argv.dbtable) === "string" ?  argv.dbtable.trim() : "state.merkletree"
     }
 
     const N = cmPols.Main.PC.length;

--- a/src/sm/sm_main/sm_main_exec.js
+++ b/src/sm/sm_main/sm_main_exec.js
@@ -60,7 +60,7 @@ module.exports = async function execute(pols, input, rom, config = {}) {
     const Fnec = new F1Field(0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141n);
 
     const db = new Database(Fr, input.db);
-    await db.connect(config.databaseURL,config.dbTable);
+    await db.connect(config.databaseURL, config.dbNodesTable, config.dbProgramTable);
     const smt = new SMT(db, poseidon, Fr);
     initState(Fr, pols);
 

--- a/src/sm/sm_main/sm_main_exec.js
+++ b/src/sm/sm_main/sm_main_exec.js
@@ -6,7 +6,7 @@ const { calculateStarkInput, calculateBatchHashData } = require("@0xpolygonherme
 const { scalar2fea, fea2scalar, fe2n, scalar2h4, h4toString,
     stringToH4, nodeIsEq, hashContractBytecode, fea2String } = require("@0xpolygonhermez/zkevm-commonjs").smtUtils;
 const SMT = require("@0xpolygonhermez/zkevm-commonjs").SMT;
-const MemDB = require("@0xpolygonhermez/zkevm-commonjs").MemDB;
+const Database = require("@0xpolygonhermez/zkevm-commonjs").Database;
 const buildPoseidon = require("@0xpolygonhermez/zkevm-commonjs").getPoseidon;
 const { byteArray2HexString } = require("@0xpolygonhermez/zkevm-commonjs").utils;
 
@@ -59,7 +59,8 @@ module.exports = async function execute(pols, input, rom, config = {}) {
     const Fec = new F1Field(0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2fn);
     const Fnec = new F1Field(0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141n);
 
-    const db = new MemDB(Fr, input.db);
+    const db = new Database(Fr, input.db);
+    await db.connect(config.databaseURL,config.dbTable);
     const smt = new SMT(db, poseidon, Fr);
     initState(Fr, pols);
 

--- a/test/sm/sm_storage/sm_storage_test.js
+++ b/test/sm/sm_storage/sm_storage_test.js
@@ -37,7 +37,7 @@ describe("Test storage operations", async function () {
         pil = await compile(fr, __dirname + "/storage_main.pil");
 
         db = new Database(fr);
-        //await db.connect("postgresql://statedb:statedb@127.0.0.1:5432/testdb");
+        // await db.connect("postgresql://statedb:statedb@127.0.0.1:5432/testdb");
         smt = new SMT(db, poseidon, fr);
     })
 

--- a/test/sm/sm_storage/sm_storage_test.js
+++ b/test/sm/sm_storage/sm_storage_test.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const { SMT, MemDB, smtUtils, getPoseidon} = require("@0xpolygonhermez/zkevm-commonjs");
+const { SMT, Database, smtUtils, getPoseidon} = require("@0xpolygonhermez/zkevm-commonjs");
 const scalar2key = require("@0xpolygonhermez/zkevm-commonjs/test/helpers/test-utils.js").scalar2key;
 const Scalar = require("ffjavascript").Scalar;
 const chai = require("chai");
@@ -35,6 +35,10 @@ describe("Test storage operations", async function () {
         fr = poseidon.F;
 
         pil = await compile(fr, __dirname + "/storage_main.pil");
+
+        db = new Database(fr);
+        //await db.connect("postgresql://statedb:statedb@127.0.0.1:5432/testdb");
+        smt = new SMT(db, poseidon, fr);
     })
 
     function initContext () {
@@ -64,9 +68,6 @@ describe("Test storage operations", async function () {
             cmPols.Main.op6[index] = 0n;
             cmPols.Main.op7[index] = 0n;
         }
-
-        db = new MemDB(fr);
-        smt = new SMT(db, poseidon, fr);
     }
 
     async function smtSet (oldRoot, key, value) {

--- a/test/smt.js
+++ b/test/smt.js
@@ -1,5 +1,5 @@
 const SMT = require("@0xpolygonhermez/zkevm-commonjs").SMT;
-const MemDB = require("@0xpolygonhermez/zkevm-commonjs").MemDB;
+const Database = require("@0xpolygonhermez/zkevm-commonjs").Database;
 const buildPoseidon = require("circomlibjs").buildPoseidon;
 const Scalar = require("ffjavascript").Scalar;
 const chai = require("chai");
@@ -16,7 +16,7 @@ describe("smt", async function () {
     })
 
     it("It should add and remove an element", async () => {
-        const db = new MemDB(F);
+        const db = new Database(F);
         const smt = new SMT(db, 4, poseidon, poseidon.F);
 
         const r1 = await smt.set(F.zero, F.e(1), Scalar.e(2));
@@ -28,7 +28,7 @@ describe("smt", async function () {
     });
 
     it("It should update an element", async () => {
-        const db = new MemDB(F);
+        const db = new Database(F);
         const smt = new SMT(db, 4, poseidon, poseidon.F);
 
         const r1 = await smt.set(F.zero, F.e(1), Scalar.e(2));
@@ -42,7 +42,7 @@ describe("smt", async function () {
 
     it("Add 128 elements", async () => {
         const N = 128;
-        const db = new MemDB(F);
+        const db = new Database(F);
         const smt = new SMT(db, 4, poseidon, poseidon.F);
 
         let r = {
@@ -68,7 +68,7 @@ describe("smt", async function () {
 
     it("Should read random", async () => {
         const N = 64;
-        const db = new MemDB(F);
+        const db = new Database(F);
         const smt = new SMT(db, 4, poseidon, poseidon.F);
 
         const vals = {};
@@ -95,7 +95,7 @@ describe("smt", async function () {
     });
 
     it("It should add elements with similar keys", async () => {
-        const db = new MemDB(F);
+        const db = new Database(F);
         const smt = new SMT(db, 4, poseidon, poseidon.F);
 
         const expectedRoot = F.e("1599843265442829753605252683384602873429861264461222121698908135665379759788");

--- a/tools/build-genesis/build_genesis.js
+++ b/tools/build-genesis/build_genesis.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const ethers = require("ethers");
 const {
-    MemDB, ZkEVMDB, processorUtils, smtUtils, getPoseidon,
+    Database, ZkEVMDB, processorUtils, smtUtils, getPoseidon,
 } = require('@0xpolygonhermez/zkevm-commonjs');
 
 // paths files
@@ -44,7 +44,7 @@ async function main(){
     const customRawTx = processorUtils.rawTxToCustomRawTx(rawTxEthers);
 
     // create a zkEVMDB and build a batch
-    const db = new MemDB(F);
+    const db = new Database(F);
 
     const zkEVMDB = await ZkEVMDB.newZkEVM(
         db,

--- a/tools/gen-input-executor/run-gen-txs.js
+++ b/tools/gen-input-executor/run-gen-txs.js
@@ -57,7 +57,7 @@ async function main(){
 
         // Init SMT DB
         const arity = 4;
-        const db = new zkcommonjs.MemDB(F);
+        const db = new zkcommonjs.Database(F);
         const smt = new zkcommonjs.SMT(db, arity, poseidon, poseidon.F);
 
         // Build genesis


### PR DESCRIPTION
The MemDB class (from the commonjs repository) has been replaced with the new Database class. This new database class supports connections to a PostgreSQL database. Anyway, the default behavior of the database class (calling only the constructor) is to use only a "memory" database in the same way that the MemDB class works.

To connect to a PostGreSQL database, you must call the Database.connection(connectionString, dbTable) function and specify the connection string to the PostGreSQL database. Optionally, you can specify the name of the table to store the data (default is "state.merkletree");

For easy of implementation and use of the Database class, if you specify "local" as connectionString, then only "memory" db (as MemDB class) will be used . 

Two new optional arguments has been added to the main_executor.js:
- [-D/--databaseURL] -> connection string to the PostGreSQL DB (if this argument is not specified, it defaults to "local")
- [-T/--dbtable] -> name of the table used to store/read data (if this argument is not specified, it defaults to "state.merkletree")

Examples:
main_executor ...... -D postgresql://statedb:statedb@127.0.0.1:5432/testdb 
main_executor ...... -D postgresql://statedb:statedb@127.0.0.1:5432/testdb -T state.merkletree


