### PR TITLE
add pil pc zero constraints, remove duplicated column on Rom plookup

### DIFF
--- a/pil/main.pil
+++ b/pil/main.pil
@@ -335,7 +335,7 @@ namespace Main(%N);
     // if elseAddr wasn't specified on zkasm, compiler put current address + 1
     zkPC' = doJMP * (finalJmpAddr - nextNoJmpZkPC) + elseJMP * (finalElseAddr - nextNoJmpZkPC) + nextNoJmpZkPC;
 
-    zKPC * Global.L1 = 0;
+    zkPC * Global.L1 = 0;
 
     (A0-op0)*assert = 0;
     (A1-op1)*assert = 0;

--- a/pil/main.pil
+++ b/pil/main.pil
@@ -335,6 +335,8 @@ namespace Main(%N);
     // if elseAddr wasn't specified on zkasm, compiler put current address + 1
     zkPC' = doJMP * (finalJmpAddr - nextNoJmpZkPC) + elseJMP * (finalElseAddr - nextNoJmpZkPC) + nextNoJmpZkPC;
 
+    zKPC * Global.L1 = 0;
+
     (A0-op0)*assert = 0;
     (A1-op1)*assert = 0;
     (A2-op2)*assert = 0;
@@ -523,13 +525,13 @@ namespace Main(%N);
     {
         CONST0, CONST1, CONST2, CONST3, CONST4, CONST5, CONST6, CONST7,
         inA, inB, inC, inROTL_C, inD, inE, inSR, inFREE,
-        inCTX, inSP, inPC, inGAS, inMAXMEM, inHASHPOS, inSTEP, inRR, inHASHPOS, inRCX,
+        inCTX, inSP, inPC, inGAS, inMAXMEM, inHASHPOS, inSTEP, inRR, inRCX,
         inCntArith, inCntBinary, inCntKeccakF, inCntMemAlign, inCntPaddingPG, inCntPoseidonG,
         operations, offset, incStack, binOpcode, jmpAddr, elseAddr, zkPC
     } in {
         Rom.CONST0, Rom.CONST1, Rom.CONST2, Rom.CONST3, Rom.CONST4, Rom.CONST5, Rom.CONST6, Rom.CONST7,
         Rom.inA, Rom.inB, Rom.inC, Rom.inROTL_C, Rom.inD, Rom.inE, Rom.inSR, Rom.inFREE,
-        Rom.inCTX, Rom.inSP, Rom.inPC, Rom.inGAS, Rom.inMAXMEM, Rom.inHASHPOS, Rom.inSTEP, Rom.inRR, Rom.inHASHPOS, Rom.inRCX,
+        Rom.inCTX, Rom.inSP, Rom.inPC, Rom.inGAS, Rom.inMAXMEM, Rom.inHASHPOS, Rom.inSTEP, Rom.inRR, Rom.inRCX,
         Rom.inCntArith, Rom.inCntBinary, Rom.inCntKeccakF, Rom.inCntMemAlign, Rom.inCntPaddingPG, Rom.inCntPoseidonG,
         Rom.operations, Rom.offset, Rom.incStack, Rom.binOpcode, Rom.jmpAddr, Rom.elseAddr, Rom.line
     };

--- a/pil/storage.pil
+++ b/pil/storage.pil
@@ -217,6 +217,7 @@ namespace Storage(%N);
     opIsZero*op0 = 0;
     pol doJump = iJmp + iJmpz*opIsZero;
     pc' = doJump*(iAddress - pc - 1) + pc + 1;
+    pc * Global.L1 = 0;
 
     // Last pc' must return to be pc=0 in order to close the program loop
     // Once the work is done, the rest of instructions must be:


### PR DESCRIPTION
issues: 
- jan#18 PC should be constrained to zero initially
- jan#13 Duplicate key and value in lookup argument 