### PR TITLE
fix/missing binary constraints

### DIFF
--- a/pil/main.pil
+++ b/pil/main.pil
@@ -77,7 +77,6 @@ namespace Main(%N);
     pol commit inCntArith, inCntBinary, inCntMemAlign, inCntKeccakF, inCntPoseidonG, inCntPaddingPG;
     pol commit incCounter;
 
-
 ///////////
 // Intermediary calculations and checks
 ///////////
@@ -208,6 +207,7 @@ namespace Main(%N);
 
     pol commit lJmpnCondValue;
     pol jmpnCondValue = JMPN*(isNeg*2**32 + op0);
+    isNeg * (1 - isNeg) = 0;
 
     lJmpnCondValue in Global.STEP;
 
@@ -227,6 +227,7 @@ namespace Main(%N);
                     2**27*hJmpnCondValueBit[4] + 2**26*hJmpnCondValueBit[3] + 2**25*hJmpnCondValueBit[2] + 2**24*hJmpnCondValueBit[1] +
                     2**23*hJmpnCondValueBit[0] + lJmpnCondValue;
 
+
     /// RCX check zero
     pol commit RCXInv;
     pol RCXIsZero = 1 - RCX*RCXInv;
@@ -242,6 +243,8 @@ namespace Main(%N);
     pol diffMem = isMaxMem* ( (maxMemRel - MAXMEM) -
                        (MAXMEM - maxMemRel) ) +
               (MAXMEM - maxMemRel);
+    isNeg * (1 - isNeg) = 0;
+    isMaxMem * (1 - isMaxMem) = 0;
 
     diffMem in Global.BYTE2;
     pol maxMemCalculated = isMaxMem*(addrRel - MAXMEM) + MAXMEM;

--- a/pil/main.pil
+++ b/pil/main.pil
@@ -243,7 +243,6 @@ namespace Main(%N);
     pol diffMem = isMaxMem* ( (maxMemRel - MAXMEM) -
                        (MAXMEM - maxMemRel) ) +
               (MAXMEM - maxMemRel);
-    isNeg * (1 - isNeg) = 0;
     isMaxMem * (1 - isMaxMem) = 0;
 
     diffMem in Global.BYTE2;

--- a/pil/mem_align.pil
+++ b/pil/mem_align.pil
@@ -98,6 +98,9 @@ namespace MemAlign(%N);
     (1 - RESET) * resultRd = 0;
     (1 - RESET) * resultWr8 = 0;
     (1 - RESET) * resultWr256 = 0;
+    resultRd * (1 - resultRd) = 0;
+    resultWr8 * (1 - resultWr8) = 0;
+    resultWr256 * (1 - resultWr256) = 0;
 
     (1 - wr8) * resultWr8 = 0;
     (1 - wr256) * resultWr256 = 0;

--- a/pil/storage.pil
+++ b/pil/storage.pil
@@ -246,6 +246,9 @@ namespace Storage(%N);
     pol constant rInRkeyBit;
     pol constant rInSiblingRkey;
     pol constant rInSiblingValueHash;
+    pol constant rInValueLow;
+    pol constant rInValueHigh;
+    pol constant rInRotlVh;
     pol constant rSetHashLeft;
     pol constant rSetHashRight;
     pol constant rSetLevel;
@@ -262,6 +265,7 @@ namespace Storage(%N);
         iHash, iHashType, iLatchGet, iLatchSet, iClimbRkey, iClimbSiblingRkey, iClimbSiblingRkeyN,
         iRotateLevel, iJmpz, iJmp, iConst0, iConst1, iConst2, iConst3, iAddress, pc,
         inFree, inNewRoot, inOldRoot, inRkey, inRkeyBit, inSiblingRkey, inSiblingValueHash,
+        inValueLow, inValueHigh, inRotlVh,
         setHashLeft, setHashRight, setLevel, setNewRoot, setOldRoot, setRkey,
         setRkeyBit, setSiblingRkey, setSiblingValueHash, setValueHigh, setValueLow
     }
@@ -270,6 +274,7 @@ namespace Storage(%N);
         rHash, rHashType, rLatchGet, rLatchSet, rClimbRkey, rClimbSiblingRkey, rClimbSiblingRkeyN,
         rRotateLevel, rJmpz, rJmp, rConst0, rConst1, rConst2, rConst3, rAddress, rLine,
         rInFree, rInNewRoot, rInOldRoot, rInRkey, rInRkeyBit, rInSiblingRkey, rInSiblingValueHash,
+        rInValueLow, rInValueHigh, rInRotlVh,
         rSetHashLeft, rSetHashRight, rSetLevel, rSetNewRoot, rSetOldRoot, rSetRkey,
         rSetRkeyBit, rSetSiblingRkey, rSetSiblingValueHash, rSetValueHigh, rSetValueLow
     }

--- a/src/sm/sm_storage/sm_storage.js
+++ b/src/sm/sm_storage/sm_storage.js
@@ -55,6 +55,9 @@ module.exports.buildConstants = async function (pols) {
         pols.rInRkeyBit[i] = l.inRKEY_BIT ? BigInt(l.inRKEY_BIT):0n;
         pols.rInSiblingRkey[i] = l.inSIBLING_RKEY ? BigInt(l.inSIBLING_RKEY):0n;
         pols.rInSiblingValueHash[i] = l.inSIBLING_VALUE_HASH ? BigInt(l.inSIBLING_VALUE_HASH):0n;
+        pols.rInValueLow[i] = l.inVALUE_LOW ? BigInt(l.inVALUE_LOW):0n;
+        pols.rInValueHigh[i] = l.inVALUE_HIGH ? BigInt(l.inVALUE_HIGH):0n;
+        pols.rInRotlVh[i] = l.inROTL_VH ? BigInt(l.inROTL_VH):0n;
 
         pols.rSetHashLeft[i] = l.setHASH_LEFT ? BigInt(l.setHASH_LEFT):0n;
         pols.rSetHashRight[i] = l.setHASH_RIGHT ? BigInt(l.setHASH_RIGHT):0n;

--- a/tools/pil_pols.js
+++ b/tools/pil_pols.js
@@ -1,0 +1,33 @@
+const fs = require("fs")
+const { compile } = require("pilcom");
+const { F1Field } = require("ffjavascript");
+
+const argv = require("yargs")
+    .usage("node pil_pols.js -p <pil> -P <pilconfig>")
+    .help('h')
+    .alias("p", "pil")
+    .alias("P", "pilconfig")
+    .argv;
+
+async function main(){
+    let Fr = new F1Field("0xFFFFFFFF00000001");
+    const pilFile = typeof(argv.pil) === "string" ?  argv.pil.trim() : "pil/main.pil";
+    const pilConfig = typeof(argv.pilconfig) === "string" ? JSON.parse(fs.readFileSync(argv.pilconfig.trim())) : {};
+
+    const pil = await compile(Fr, pilFile, null, pilConfig);
+    const pilDeg = Object.values(pil.references)[0].polDeg;
+
+    let pols = {};
+    for(let key in pil.references) {
+        if (pil.references[key].type != 'cmP') continue;
+        console.log(key);
+    }
+}
+
+main().then(()=> {
+    process.exit(0);
+}, (err) => {
+    console.log(err.message);
+    console.log(err.stack);
+    process.exit(1);
+});


### PR DESCRIPTION
Add missing constraints for binary pols (Main.isNeg, Main.isMaxMem)
Add missing plookup columns on Storage.ROM for pols Storage.inValueLow, Storage.inValueHigh, Storage.inRotlVh
Add extra binary constraints for pols (Mem.resultRd, Mem.resultWr256, Mem.resultWr8). If values there aren't 0 or 1, fail plookup with Main and proof could not be generated.