### PR TITLE
Remove stop opcode from simple transfers

### DIFF
--- a/src/sm/sm_main/debug/full-tracer.js
+++ b/src/sm/sm_main/debug/full-tracer.js
@@ -313,6 +313,12 @@ class FullTracer {
             if (this.finalTrace.responses[this.finalTrace.responses.length - 1].error === "") {
                 this.finalTrace.responses[this.finalTrace.responses.length - 1].error = lastOpcode.error;
             }
+
+            // If only opcode is STOP, remove redundancy
+            if(this.info.length === 1 && this.info[0].opcode === "STOP" && this.finalTrace.responses[this.finalTrace.responses.length - 1].call_trace.context.data === '0x') {
+                this.finalTrace.responses[this.finalTrace.responses.length - 1].execution_trace = [];
+                this.finalTrace.responses[this.finalTrace.responses.length - 1].call_trace.steps = [];
+            }
             // Remove not requested data
             if (!generate_execute_trace) {
                 delete this.finalTrace.responses[this.finalTrace.responses.length - 1].execution_trace

--- a/src/sm/sm_main/debug/full-tracer.js
+++ b/src/sm/sm_main/debug/full-tracer.js
@@ -315,7 +315,7 @@ class FullTracer {
             }
 
             // If only opcode is STOP, remove redundancy
-            if(this.info.length === 1 && this.info[0].opcode === "STOP" && this.finalTrace.responses[this.finalTrace.responses.length - 1].call_trace.context.data === '0x') {
+            if(this.finalTrace.responses[this.finalTrace.responses.length - 1].call_trace.context.data === '0x') {
                 this.finalTrace.responses[this.finalTrace.responses.length - 1].execution_trace = [];
                 this.finalTrace.responses[this.finalTrace.responses.length - 1].call_trace.steps = [];
             }


### PR DESCRIPTION
From ROM side, a transfer is interpreted as a call to a 0x0 bytecode address (EOA) so it process a STOP (0x00) opcode. Consequently, on tracer steps, for transfers it appears the STOP opcode. This behavior is different from geth.
This PR removes the opcode for that kind of transactions