### PR TITLE
fix: eventLog return 0

### DIFF
--- a/src/sm/sm_main/sm_main_exec.js
+++ b/src/sm/sm_main/sm_main_exec.js
@@ -2473,6 +2473,7 @@ function eval_eventLog(ctx, tag) {
         fullTracer.handleEvent(ctx, tag);
     if (debug && tag.params[0].varName == 'onError')
         console.log(`Error triggered zkrom: ${tag.params[1].varName}\nsource: ${ctx.sourceRef}`);
+    return [ctx.Fr.zero, ctx.Fr.zero, ctx.Fr.zero, ctx.Fr.zero, ctx.Fr.zero, ctx.Fr.zero, ctx.Fr.zero, ctx.Fr.zero];
 }
 
 function eval_cond(ctx, tag) {


### PR DESCRIPTION
when executing `eventLog`,  it returns undefined, and will raise issue here:  https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/src/sm/sm_main/sm_main_exec.js#L752.  