### PR TITLE
Fix getFromMemory function bug

### DIFF
--- a/src/sm/sm_main/debug/full-tracer-utils.js
+++ b/src/sm/sm_main/debug/full-tracer-utils.js
@@ -141,7 +141,7 @@ function getFromMemory(offset, length, ctx, customCTX) {
         finalMemory = finalMemory.concat(hexStringEnd);
     }
 
-    return finalMemory;
+    return finalMemory.substring(0, length * 2 + 2);
 }
 
 /**


### PR DESCRIPTION
The `getFromMemory` function of the tracer was failing when trying to retrieve less than 32 bytes from a memory slot.