### PR TITLE
Modifying final.circom to use lessthangl.circom file

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "fs": "^0.0.1-security",
     "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",
-    "pil-stark": "https://github.com/0xPolygonHermez/pil-stark.git#develop",
+    "pil-stark": "https://github.com/0xPolygonHermez/pil-stark.git#feature/constRootTranscript",
     "pilcom": "0.0.23",
     "snarkjs": "0.7.0",
     "yargs": "^17.4.0"

--- a/recursive/final.circom
+++ b/recursive/final.circom
@@ -17,20 +17,9 @@ Total: 1696
 
 include "sha256/sha256.circom";
 include "bitify.circom";
+include "lessthangl.circom";
 include "recursivef.verifier.circom";
 
-template LessThanGoldilocks() {
-    var n = 64;
-    var p = 0xFFFFFFFF00000001;
-    signal input in;
-    signal output out;
-
-    component n2b = Num2Bits(n+1);
-
-    n2b.in <== in + (1<<n) - p;
-
-    out <== 1-n2b.out[n];
-}
 
 template Main() {
     signal output publicsHash;
@@ -129,10 +118,8 @@ template Main() {
         }
     }
 
-    signal isValidOldStateRoot[4];
     for (var i = 0; i < 4; i++) {
-        isValidOldStateRoot[i] <== LessThanGoldilocks()(publics[0 + 2*i] + (1 << 32) * publics[0 + 2*i + 1]);
-        isValidOldStateRoot[i] === 1;
+        _<== LessThanGoldilocks()(publics[0 + 2*i] + (1 << 32) * publics[0 + 2*i + 1]);
     }
 
     signal n2bOldAccInputHash[8][32];
@@ -170,10 +157,8 @@ template Main() {
         }
     }
 
-    signal isValidNewStateRoot[4];
     for (var i = 0; i < 4; i++) {
-        isValidNewStateRoot[i] <== LessThanGoldilocks()(publics[19 + 2*i] + (1 << 32)*publics[19 + 2*i + 1]);
-        isValidNewStateRoot[i] === 1;
+        _<== LessThanGoldilocks()(publics[19 + 2*i] + (1 << 32)*publics[19 + 2*i + 1]);
     }
 
     signal n2bNewAccInputHash[8][32];


### PR DESCRIPTION
This PR modifies final.circom template so that it uses the `LessThanGoldilocks` template defined in `lessthangl.circom` inside pil-stark, since otherwise we would get a duplicate error.