### PR TITLE
set timestamp reading from state when skipping changeL2Block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.7.tgz",
-      "integrity": "sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==",
+      "version": "20.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.9.tgz",
+      "integrity": "sha512-CQXNuMoS/VcoAMISe5pm4JnEd1Br5jildbQEToEMQvutmv+EaQr90ry9raiudgpyDuqFiV9e4rnjSfLNq12M5w==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2810,9 +2810,9 @@
       "integrity": "sha512-r5ZDbgImvVWCP0lA/cGNgQcZqR+aYdFx3u+CtJqUE510pBUVGMn4ulL/iRTI4tACTYsNJ736uzFxEBXesPAktA=="
     },
     "node_modules/fastq": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.0.tgz",
+      "integrity": "sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"

--- a/src/sm/sm_main/debug/full-tracer-utils.js
+++ b/src/sm/sm_main/debug/full-tracer-utils.js
@@ -80,17 +80,6 @@ function getVarFromCtx(ctx, global, varLabel, customCTX) {
 }
 
 /**
- * Set a global variable
- * @param {Object} ctx current context object
- * @param {String} varLabel name of the label
- * @param {Array[BigInt]} valueToSet value in the form of [op0, .., op7]
- */
-function setGlobalVar(ctx, varLabel, valueToSet) {
-    const addressMem = findOffsetLabel(ctx.rom.program, varLabel);
-    ctx.mem[addressMem] = valueToSet;
-}
-
-/**
  * Get the value of a reg (A, B, C, D, E...)
  * @param {Object} ctx current context object
  * @param {String} reg label string of the reg to retrieve
@@ -207,5 +196,4 @@ module.exports = {
     getConstantFromCtx,
     bnToPaddedHex,
     convertBigIntsToNumbers,
-    setGlobalVar,
 };

--- a/src/sm/sm_main/debug/full-tracer-utils.js
+++ b/src/sm/sm_main/debug/full-tracer-utils.js
@@ -80,6 +80,17 @@ function getVarFromCtx(ctx, global, varLabel, customCTX) {
 }
 
 /**
+ * Set a global variable
+ * @param {Object} ctx current context object
+ * @param {String} varLabel name of the label
+ * @param {Array[BigInt]} valueToSet value in the form of [op0, .., op7]
+ */
+function setGlobalVar(ctx, varLabel, valueToSet) {
+    const addressMem = findOffsetLabel(ctx.rom.program, varLabel);
+    ctx.mem[addressMem] = valueToSet;
+}
+
+/**
  * Get the value of a reg (A, B, C, D, E...)
  * @param {Object} ctx current context object
  * @param {String} reg label string of the reg to retrieve
@@ -196,4 +207,5 @@ module.exports = {
     getConstantFromCtx,
     bnToPaddedHex,
     convertBigIntsToNumbers,
+    setGlobalVar,
 };

--- a/src/sm/sm_main/sm_main_exec.js
+++ b/src/sm/sm_main/sm_main_exec.js
@@ -226,9 +226,10 @@ module.exports = async function execute(pols, input, rom, config = {}, metadata 
 
             const feaInitSR = scalar2fea(ctx.Fr, Scalar.e(ctx.input.oldStateRoot));
             const res = await smt.get(sr8to4(ctx.Fr, feaInitSR), keyToRead);
-            const timestampFromSR = Scalar.e(res.value);
-            console.log('timestampFromSR: ', timestampFromSR);
-            fullTracerUtils.setGlobalVar(ctx, 'timestamp', scalar2fea(ctx.Fr, timestampFromSR));
+
+            // write in memory
+            const addressMem = fullTracerUtils.findOffsetLabel(ctx.rom.program, 'timestamp');
+            ctx.mem[addressMem] = scalar2fea(ctx.Fr, Scalar.e(res.value));
         }
 
     for (let step = 0; step < stepsN; step++) {

--- a/src/sm/sm_main/sm_main_exec.js
+++ b/src/sm/sm_main/sm_main_exec.js
@@ -26,11 +26,13 @@ const {
 const ConstantsCommon = require('@0xpolygonhermez/zkevm-commonjs').Constants;
 
 const FullTracer = require("./debug/full-tracer");
+const fullTracerUtils = require("./debug/full-tracer-utils");
 const Prints = require("./debug/prints");
 const StatsTracer = require("./debug/stats-tracer");
 const { lstat } = require("fs");
 const MyHelperClass = require("./helpers/helpers");
 const Constants = require('./const-sm-main-exec');
+const { get } = require("lodash");
 
 const twoTo255 = Scalar.shl(Scalar.one, 255);
 const twoTo256 = Scalar.shl(Scalar.one, 256);
@@ -201,6 +203,34 @@ module.exports = async function execute(pols, input, rom, config = {}, metadata 
     }
     ctx.helpers = helpers;
     try {
+
+        // This code is only used when 'skipFirstChangeL2Block = true'
+        // This only is triggered when executong transaction by transaction across batches
+        // This cannot be executed in prover mode
+        // This code aims to set the timestamp of the batch to the one read from the state
+        // Issue fixed: timestamp is set when processed a 'changeL2Block', stored on state and hold on memory.
+        // Later on, 'opTIMESTAMP' loads the value hold on memory.
+        // Hence, execution transaction by transaction lost track of the timestamp
+        // This function aims to solve the abive issue by loading the timestamp from the state
+        if (input.skipFirstChangeL2Block === true) {
+            // this smt key is built with the following registers:
+            // A: `0x000000000000000000000000000000005ca1ab1e` (%ADDRESS_SYSTEM)
+            // B: `3` (%SMT_KEY_SC_STORAGE)
+            // C: `2` (%TIMESTAMP_STORAGE_POS)
+            const keyToRead = [
+                13748230500842749409n,
+                4428676446262882967n,
+                12167292013585018040n,
+                12161933621946006603n,
+            ];
+
+            const feaInitSR = scalar2fea(ctx.Fr, Scalar.e(ctx.input.oldStateRoot));
+            const res = await smt.get(sr8to4(ctx.Fr, feaInitSR), keyToRead);
+            const timestampFromSR = Scalar.e(res.value);
+            console.log('timestampFromSR: ', timestampFromSR);
+            fullTracerUtils.setGlobalVar(ctx, 'timestamp', scalar2fea(ctx.Fr, timestampFromSR));
+        }
+
     for (let step = 0; step < stepsN; step++) {
         const i = step % N;
         ctx.ln = Fr.toObject(pols.zkPC[i]);


### PR DESCRIPTION
- add special function to handle `timestamp` across batches when executing transaction by transaction
  - basically, loads `timestamp` from state and store it in memory 