### PR TITLE
fix an error with helpers call ARITH_BN254_ADDFP2 and ARITH_BN254_SUBFP2

### DIFF
--- a/test/diagnostic/command/helpers.zkasm
+++ b/test/diagnostic/command/helpers.zkasm
@@ -93,7 +93,7 @@
         ${ARITH_BN254_ADDFP2(A,B)} => A
         4 :ASSERT
         15 => A
-        12 => B
+        8 => B
         3 => C,D
         ${ARITH_BN254_SUBFP2(C,D)} => A
         0 :ASSERT

--- a/test/diagnostic/command/helpers.zkasm
+++ b/test/diagnostic/command/helpers.zkasm
@@ -90,9 +90,9 @@
 
         2 => A,B
         3 => C,D
-        ${ARITH_BN254_ADDFP2(A,B,C,D)} => A
+        ${ARITH_BN254_ADDFP2(A,B)} => A
         4 :ASSERT
         2 => A,B
         3 => C,D
-        ${ARITH_BN254_SUBFP2(A,B,C,D)} => A
+        ${ARITH_BN254_SUBFP2(C,D)} => A
         0 :ASSERT

--- a/test/diagnostic/command/helpers.zkasm
+++ b/test/diagnostic/command/helpers.zkasm
@@ -92,7 +92,8 @@
         3 => C,D
         ${ARITH_BN254_ADDFP2(A,B)} => A
         4 :ASSERT
-        2 => A,B
+        15 => A
+        12 => B
         3 => C,D
         ${ARITH_BN254_SUBFP2(C,D)} => A
         0 :ASSERT


### PR DESCRIPTION
in helper zkasm test, ARITH_BN254_ADDFP2 and ARITH_BN254_SUBFP2 is called with four parameters, but only use 2. Fix this test because fail when test it with prover C++ version.