### PR TITLE
fix the audit issues (comments and unused constants) issues: 1,2,3

### DIFF
--- a/pil/arith.pil
+++ b/pil/arith.pil
@@ -9,19 +9,19 @@
     EQ3:   s * s - x1 - x2 - x3 + (q1 * p1)         x3             1+2       2,3    ARITH_ECADD_DIFFERENT, ARITH_ECADD_SAME
     EQ4:   s * x1 - s * x3 - y1 - y3 + (q2 * p1)    y3             1+2       2,3    ARITH_ECADD_DIFFERENT, ARITH_ECADD_SAME
 
-    EQ5:   x1 * x2 - y1 * y2 - x3 + (q1 * p2)                        4         4    ARITH_BN254_MULFP2
-    EQ6:   y1 * x2 + x1 * y2 - y3 + (q2 * p2)                        4         4    ARITH_BN254_MULFP2
+    EQ5:   x1 * x2 - y1 * y2 - x3 + (q1 * p2)                        3         4    ARITH_BN254_MULFP2
+    EQ6:   y1 * x2 + x1 * y2 - y3 + (q2 * p2)                        3         4    ARITH_BN254_MULFP2
 
-	EQ7:   x1 + x2 - x3 + (q1 * p2)                                  5         5    ARITH_BN254_ADDFP2
-	EQ8:   y1 + y2 - y3 + (q2 * p2)                                  5         5    ARITH_BN254_ADDFP2
+	EQ7:   x1 + x2 - x3 + (q1 * p2)                                  4         5    ARITH_BN254_ADDFP2
+	EQ8:   y1 + y2 - y3 + (q2 * p2)                                  4         5    ARITH_BN254_ADDFP2
 
-	EQ9:   x1 - x2 - x3 + (q1 * p2)                                  6         6    ARITH_BN254_SUBFP2
-	EQ10:  y1 - y2 - y3 + (q2 * p2)                                  6         6    ARITH_BN254_SUBFP2
+	EQ9:   x1 - x2 - x3 + (q1 * p2)                                  5         6    ARITH_BN254_SUBFP2
+	EQ10:  y1 - y2 - y3 + (q2 * p2)                                  5         6    ARITH_BN254_SUBFP2
 
-    EQ11:  s * x2 - s * x1 - y2 + y1 + (q0 * p3)    lambda - ADD     7         7    ARITH_SECP256R1_ECADD_DIFFERENT
-    EQ12:  2 * s * y1 - 3 * x1 * x1 - a + (q0 * p3) lambda - DBL     8         8    ARITH_SECP256R1_ECADD_SAME
-    EQ13:  s * s - x1 - x2 - x3 + (q1 * p3)         x3             7+8       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
-    EQ14:  s * x1 - s * x3 - y1 - y3 + (q2 * p3)    y3             7+8       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
+    EQ11:  s * x2 - s * x1 - y2 + y1 + (q0 * p3)    lambda - ADD     6         7    ARITH_SECP256R1_ECADD_DIFFERENT
+    EQ12:  2 * s * y1 - 3 * x1 * x1 - a + (q0 * p3) lambda - DBL     7         8    ARITH_SECP256R1_ECADD_SAME
+    EQ13:  s * s - x1 - x2 - x3 + (q1 * p3)         x3             6+7       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
+    EQ14:  s * x1 - s * x3 - y1 - y3 + (q2 * p3)    y3             6+7       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
 
     where p1 refers to the base field order of:
         · Secp256k1:  0xFFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFE FFFF FC2F

--- a/pil/rom.pil
+++ b/pil/rom.pil
@@ -23,7 +23,7 @@ namespace Rom(%N);
 
     /*
       comment genereated with:
-      node tools/pil_pol_table/bits_compose.js "arith,arithSame12,arithUseE,assert,bin,hashK,hashKDigest,hashKLen,hashP,hashPDigest,hashPLen,ind,indRR,isMem,isStack,JMP,JMPC,JMPN,memAlignRD,memAlignWR,memAlignWR8,mOp,mWR,repeat,setA,setB,setC,setCTX,setD,setE,setGAS,setHASHPOS,setPC,setRCX,setRR,setSP,setSR,sRD,sWR,useCTX,useJmpAddr,JMPZ,call,return,hashK1,hashP1,useElseAddr,hashS,hashSDigest,hashSLen,hashS1"
+      node tools/pil_pol_table/bits_compose.js "arith,arithSame12,arithUseE,assert,bin,hashK,hashKDigest,hashKLen,hashP,hashPDigest,hashPLen,ind,indRR,isMem,isStack,JMP,JMPC,JMPN,memAlignRD,memAlignWR,memAlignWR8,mOp,mWR,repeat,setA,setB,setC,setCTX,setD,setE,setGAS,setHASHPOS,setPC,setRCX,setRR,setSP,setSR,sRD,sWR,useCTX,useJmpAddr,JMPZ,call,return,hashK1,hashP1,useElseAddr,hashS,hashSDigest,hashSLen,hashS1,assumeFree"
 
       operations =
               2**0  * arith         + 2**1  * arithSame12   + 2**2  * arithUseE     + 2**3  * assert
@@ -38,6 +38,5 @@ namespace Rom(%N);
             + 2**36 * setSR         + 2**37 * sRD           + 2**38 * sWR           + 2**39 * useCTX
             + 2**40 * useJmpAddr    + 2**41 * JMPZ          + 2**42 * call          + 2**43 * return
             + 2**44 * hashK1        + 2**45 * hashP1        + 2**46 * useElseAddr   + 2**47 * hashS
-            + 2**48 * hashSDigest   + 2**49 * hashSLen      + 2**50 * hashS1;
-
+            + 2**48 * hashSDigest   + 2**49 * hashSLen      + 2**50 * hashS1        + 2**51 * assumeFree;
     */

--- a/src/sm/sm_rom.js
+++ b/src/sm/sm_rom.js
@@ -10,12 +10,6 @@ module.exports.buildConstants = async function buildConstants(pols, rom) {
 
     const N = pols.offset.length;
 
-    const twoTo31 = Scalar.e(0x80000000);
-    const maxInt = 2147483647;
-    const minInt = -2147483648;
-    const maxUInt = 0xFFFFFFFF;
-    const minUInt = 0;
-
     if (rom.program.length>N) throw new Error("Rom is too big for this N");
 
     for (let i=0; i<N; i++) {

--- a/tools/arith/arith.ejs.pil
+++ b/tools/arith/arith.ejs.pil
@@ -9,19 +9,19 @@
     EQ3:   s * s - x1 - x2 - x3 + (q1 * p1)         x3             1+2       2,3    ARITH_ECADD_DIFFERENT, ARITH_ECADD_SAME
     EQ4:   s * x1 - s * x3 - y1 - y3 + (q2 * p1)    y3             1+2       2,3    ARITH_ECADD_DIFFERENT, ARITH_ECADD_SAME
 
-    EQ5:   x1 * x2 - y1 * y2 - x3 + (q1 * p2)                        4         4    ARITH_BN254_MULFP2
-    EQ6:   y1 * x2 + x1 * y2 - y3 + (q2 * p2)                        4         4    ARITH_BN254_MULFP2
+    EQ5:   x1 * x2 - y1 * y2 - x3 + (q1 * p2)                        3         4    ARITH_BN254_MULFP2
+    EQ6:   y1 * x2 + x1 * y2 - y3 + (q2 * p2)                        3         4    ARITH_BN254_MULFP2
 
-	EQ7:   x1 + x2 - x3 + (q1 * p2)                                  5         5    ARITH_BN254_ADDFP2
-	EQ8:   y1 + y2 - y3 + (q2 * p2)                                  5         5    ARITH_BN254_ADDFP2
+	EQ7:   x1 + x2 - x3 + (q1 * p2)                                  4         5    ARITH_BN254_ADDFP2
+	EQ8:   y1 + y2 - y3 + (q2 * p2)                                  4         5    ARITH_BN254_ADDFP2
 
-	EQ9:   x1 - x2 - x3 + (q1 * p2)                                  6         6    ARITH_BN254_SUBFP2
-	EQ10:  y1 - y2 - y3 + (q2 * p2)                                  6         6    ARITH_BN254_SUBFP2
+	EQ9:   x1 - x2 - x3 + (q1 * p2)                                  5         6    ARITH_BN254_SUBFP2
+	EQ10:  y1 - y2 - y3 + (q2 * p2)                                  5         6    ARITH_BN254_SUBFP2
 
-    EQ11:  s * x2 - s * x1 - y2 + y1 + (q0 * p3)    lambda - ADD     7         7    ARITH_SECP256R1_ECADD_DIFFERENT
-    EQ12:  2 * s * y1 - 3 * x1 * x1 - a + (q0 * p3) lambda - DBL     8         8    ARITH_SECP256R1_ECADD_SAME
-    EQ13:  s * s - x1 - x2 - x3 + (q1 * p3)         x3             7+8       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
-    EQ14:  s * x1 - s * x3 - y1 - y3 + (q2 * p3)    y3             7+8       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
+    EQ11:  s * x2 - s * x1 - y2 + y1 + (q0 * p3)    lambda - ADD     6         7    ARITH_SECP256R1_ECADD_DIFFERENT
+    EQ12:  2 * s * y1 - 3 * x1 * x1 - a + (q0 * p3) lambda - DBL     7         8    ARITH_SECP256R1_ECADD_SAME
+    EQ13:  s * s - x1 - x2 - x3 + (q1 * p3)         x3             6+7       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
+    EQ14:  s * x1 - s * x3 - y1 - y3 + (q2 * p3)    y3             6+7       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
 
     where p1 refers to the base field order of:
         · Secp256k1:  0xFFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFE FFFF FC2F


### PR DESCRIPTION
### ISSUE 1
PATH: pil/rom.pil
Rom SM contains an operations constant polynomial which is constructed in the Executor. The operations polynomial doesn't include assumeFree in the generated comment.
```
/*
  comment genereated with:
  node tools/pil_pol_table/bits_compose.js "arith,arithSame12,arithUseE,assert,bin,hashK,hashKDigest,hashKLen,hashP,hashPDigest,hashPLen,ind,indRR,isMem,isStack,JMP,JMPC,JMPN,memAlignRD,memAlignWR,memAlignWR8,mOp,mWR,repeat,setA,setB,setC,setCTX,setD,setE,setGAS,setHASHPOS,setPC,setRCX,setRR,setSP,setSR,sRD,sWR,useCTX,useJmpAddr,JMPZ,call,return,hashK1,hashP1,useElseAddr,hashS,hashSDigest,hashSLen,hashS1"

  operations =
          2**0  * arith         + 2**1  * arithSame12   + 2**2  * arithUseE     + 2**3  * assert
        + 2**4  * bin           + 2**5  * hashK         + 2**6  * hashKDigest   + 2**7  * hashKLen
        + 2**8  * hashP         + 2**9  * hashPDigest   + 2**10 * hashPLen      + 2**11 * ind
        + 2**12 * indRR         + 2**13 * isMem         + 2**14 * isStack       + 2**15 * JMP
        + 2**16 * JMPC          + 2**17 * JMPN          + 2**18 * memAlignRD    + 2**19 * memAlignWR
        + 2**20 * memAlignWR8   + 2**21 * mOp           + 2**22 * mWR           + 2**23 * repeat
        + 2**24 * setA          + 2**25 * setB          + 2**26 * setC          + 2**27 * setCTX
        + 2**28 * setD          + 2**29 * setE          + 2**30 * setGAS        + 2**31 * setHASHPOS
        + 2**32 * setPC         + 2**33 * setRCX        + 2**34 * setRR         + 2**35 * setSP
        + 2**36 * setSR         + 2**37 * sRD           + 2**38 * sWR           + 2**39 * useCTX
        + 2**40 * useJmpAddr    + 2**41 * JMPZ          + 2**42 * call          + 2**43 * return
        + 2**44 * hashK1        + 2**45 * hashP1        + 2**46 * useElseAddr   + 2**47 * hashS
        + 2**48 * hashSDigest   + 2**49 * hashSLen      + 2**50 * hashS1;

*/
```
**Remediation**
Include assumeFree in the operations polynomial.

### ISSUE 2
PATH: tools/arith/arith.ejs.pil, pil/arith.pil
The Arithmetic State Machine handles Elliptic Curve operations. Polygon zkEVM supports several curves: Secp256k1, BN254, Secp256r1. Arith SM has an equation selector to choose the curve:

```
pol sel_secp256k1 = selEq[1] + selEq[2];
pol sel_bn254 = selEq[3] + selEq[4] + selEq[5];
pol sel_secp256r1 = selEq[6] + selEq[7];
```
The selector equation for BN254, Secp256r1 curves in the comment( selEq column) mismatches from the PIL one:
```
/*
    Equations:
                                                                 selEq   arithEq
    EQ0:   A(x1) * B(y1) + C(x2) = D (y2) * 2 ** 256 + op (y3)       0         1    ARITH
    EQ1:   s * x2 - s * x1 - y2 + y1 + (q0 * p1)    lambda - ADD     1         2    ARITH_ECADD_DIFFERENT
    EQ2:   2 * s * y1 - 3 * x1 * x1 + (q0 * p1)     lambda - DBL     2         3    ARITH_ECADD_SAME
    EQ3:   s * s - x1 - x2 - x3 + (q1 * p1)         x3             1+2       2,3    ARITH_ECADD_DIFFERENT, ARITH_ECADD_SAME
    EQ4:   s * x1 - s * x3 - y1 - y3 + (q2 * p1)    y3             1+2       2,3    ARITH_ECADD_DIFFERENT, ARITH_ECADD_SAME
    EQ5:   x1 * x2 - y1 * y2 - x3 + (q1 * p2)                        4         4    ARITH_BN254_MULFP2
    EQ6:   y1 * x2 + x1 * y2 - y3 + (q2 * p2)                        4         4    ARITH_BN254_MULFP2
    EQ7:   x1 + x2 - x3 + (q1 * p2)                                  5         5    ARITH_BN254_ADDFP2
    EQ8:   y1 + y2 - y3 + (q2 * p2)                                  5         5    ARITH_BN254_ADDFP2
    EQ9:   x1 - x2 - x3 + (q1 * p2)                                  6         6    ARITH_BN254_SUBFP2
    EQ10:  y1 - y2 - y3 + (q2 * p2)                                  6         6    ARITH_BN254_SUBFP2
    EQ11:  s * x2 - s * x1 - y2 + y1 + (q0 * p3)    lambda - ADD     7         7    ARITH_SECP256R1_ECADD_DIFFERENT
    EQ12:  2 * s * y1 - 3 * x1 * x1 - a + (q0 * p3) lambda - DBL     8         8    ARITH_SECP256R1_ECADD_SAME
    EQ13:  s * s - x1 - x2 - x3 + (q1 * p3)         x3             7+8       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
    EQ14:  s * x1 - s * x3 - y1 - y3 + (q2 * p3)    y3             7+8       7,8    ARITH_SECP256R1_ECADD_DIFFERENT, ARITH_SECP256R1_ECADD_SAME
    ...
*/
```
**Remediation**
Fix selEq values in the comment for EQ5-EQ14.

### ISSUE 3
PATH: sm_rom.js
```
buildConstants method contains unused variables:
const twoTo31 = Scalar.e(0x80000000);
const maxInt = 2147483647;
const minInt = -2147483648;
const maxUInt = 0xFFFFFFFF;
const minUInt = 0;
```
